### PR TITLE
Only show command when repo is found

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,13 +14,13 @@
 		"type": "git",
 		"url": "https://github.com/blackgirlbytes/vscodeextension-deploy-to-gh-pages"
 	},
-    "keywords": [
-        "github",
-        "github pages"
-    ],
-    "categories": [
-        "Education",
-        "Other"
+	"keywords": [
+		"github",
+		"github pages"
+	],
+	"categories": [
+		"Education",
+		"Other"
 	],
 	"activationEvents": [
 		"*"
@@ -30,7 +30,8 @@
 		"commands": [
 			{
 				"command": "extension.deployToGitHubPages",
-				"title": "Deploy to GitHub Pages"
+				"title": "Deploy to GitHub Pages",
+				"enablement": "gitOpenRepositoryCount >= 1"
 			}
 		]
 	},

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
 		"commands": [
 			{
 				"command": "extension.deployToGitHubPages",
-				"title": "Deploy to GitHub Pages",
-				"enablement": "gitOpenRepositoryCount >= 1"
+				"title": "Deploy to GitHub Pages"
 			}
 		]
 	},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,11 +8,11 @@ export async function activate(context: vscode.ExtensionContext) {
 	const credentials = new Credentials();
 	const repositories = new Repositories();
 	await credentials.initialize(context);
-	
+
 	const disposable = vscode.commands.registerCommand('extension.deployToGitHubPages', async () => {
 		const octokit = await credentials.getOctokit();
 		const userInfo = await octokit.users.getAuthenticated();
-		const quickPickList = await repositories.handleQuickPickList(userInfo, octokit)
+		const quickPickList = await repositories.handleQuickPickList(userInfo, octokit);
 	});
 
 	context.subscriptions.push(disposable);

--- a/src/repositories.ts
+++ b/src/repositories.ts
@@ -6,16 +6,16 @@ export class Repositories {
         let repoList;
         try {
             repoList = await octokit.repos.listForUser({ username: userInfo.data.login, sort: 'created' });
-            return repoList
+            return repoList;
 
         } catch (err) {
-            console.log(err)
+            console.log(err);
         }
-        return repoList
+        return repoList;
     }
-    
+
     async postToGitHubPages(repo: any, branch: any, userInfo: any, octokit: Octokit) {
-        let message: string = 'Unable to post on GitHub Pages'
+        let message = 'Unable to post on GitHub Pages';
         try {
 
             const result = await octokit.repos.createPagesSite({
@@ -25,30 +25,30 @@ export class Repositories {
                     branch: branch,
                     path: '/'
                 }
-            })
+            });
             if (result) {
                 if (result.status === 201) {
-                    message = `Your GitHub Page will be available in a few minutes on: https://${userInfo.data.login}.github.io/${repo}/`
+                    message = `Your GitHub Page will be available in a few minutes on: https://${userInfo.data.login}.github.io/${repo}/`;
                 }
             }
         } catch (err: any) {
-            message = err.message
+            message = err.message;
         } finally {
             vscode.window.showInformationMessage(message);
         }
     }
     async handleQuickPickList(userInfo: any, octokit: Octokit) {
-        const repoList = await this.getRepoList(userInfo, octokit)
+        const repoList = await this.getRepoList(userInfo, octokit);
         try {
             if (repoList) {
                 // add a theme icon to quick pick item 
-                let items: vscode.QuickPickItem[] = repoList.data.map(({ full_name, name, default_branch }) => ({
+                const items: vscode.QuickPickItem[] = repoList.data.map(({ full_name, name, default_branch }) => ({
                     label: `$(repo) Host on GitHub Pages: ${full_name}`,
                     description: name,
                     detail: default_branch,
                 }));
 
-                vscode.window.showQuickPick(items, {placeHolder: 'Choose the repo you want to deploy to GitHub Pages'}).then(selection => {
+                vscode.window.showQuickPick(items, { placeHolder: 'Choose the repo you want to deploy to GitHub Pages' }).then(selection => {
                     // the user canceled the selection
                     if (!selection) {
                         return;
@@ -59,11 +59,11 @@ export class Repositories {
                             if (answer === `Publish`) {
                                 this.postToGitHubPages(selection.description, selection.detail, userInfo, octokit);
                             }
-                        })
-                })
+                        });
+                });
             }
         } catch (err) {
-            console.log(err)
+            console.log(err);
         }
 
     }

--- a/src/repositories.ts
+++ b/src/repositories.ts
@@ -38,6 +38,13 @@ export class Repositories {
         }
     }
     async handleQuickPickList(userInfo: any, octokit: Octokit) {
+
+        // make sure this project is a git repository
+        const result: Array<string> | undefined = await vscode.commands.executeCommand('git.api.getRepositories');
+        if (result && result.length < 1) {
+            return vscode.window.showInformationMessage("This project doesn't appear to be a git repo. Make sure you have published your project to GitHub before you enable GitHub Pages.");
+        }
+
         const repoList = await this.getRepoList(userInfo, octokit);
         try {
             if (repoList) {


### PR DESCRIPTION
By default, the command is visible even when the user isn't using any source control at all. I think that we only want to show this command if the current workspace is a valid GitHub repo.  This change only accounts for git, but is a start.

Also - I let eslint format the code. Can back this change out if you would prefer it not be munged with this one or you prefer to a different formatting.