### PR TITLE
Rollback check for git

### DIFF
--- a/src/repositories.ts
+++ b/src/repositories.ts
@@ -38,13 +38,6 @@ export class Repositories {
         }
     }
     async handleQuickPickList(userInfo: any, octokit: Octokit) {
-
-        // make sure this project is a git repository
-        const result: Array<string> | undefined = await vscode.commands.executeCommand('git.api.getRepositories');
-        if (result && result.length < 1) {
-            return vscode.window.showInformationMessage("This project doesn't appear to be a git repo. Make sure you have published your project to GitHub before you enable GitHub Pages.");
-        }
-
         const repoList = await this.getRepoList(userInfo, octokit);
         try {
             if (repoList) {


### PR DESCRIPTION
This PR rolls back #1. The git api that I'm using isn't available on the web. i'll need to figure out what to do instead. In the meantime, this change will at least allow the extension to work on the web with #3.